### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,4 +1,6 @@
 name: "ShellCheck"
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/melihcelenk/MyLinuxHelper/security/code-scanning/1](https://github.com/melihcelenk/MyLinuxHelper/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` block at the workflow level or directly under the relevant job. In this case, the simplest and best fix is to add a `permissions` block at the root (top) level of `.github/workflows/shellcheck.yml`, so it applies to all jobs. Since the workflow only needs to read repository contents, use `contents: read` as the minimum required. No code logic or functionality needs to change; just add these lines directly below the workflow's `name` field (after line 1 and before `on:`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
